### PR TITLE
Fix logout promise

### DIFF
--- a/src/config/firebase.js
+++ b/src/config/firebase.js
@@ -41,7 +41,8 @@ const loginWithGoogle = async () => {
   return userCredential;
 };
 
-const logout = () => { signOut(auth); }
+// Allow callers to await logout completion
+const logout = () => signOut(auth);
 
 export {
   app,


### PR DESCRIPTION
## Summary
- return promise from logout to allow awaiting sign-out

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b279f3344832b8974e7c6bd267c75